### PR TITLE
Kindly Try with this changes.

### DIFF
--- a/rootdir/recovery/twrp.fstab
+++ b/rootdir/recovery/twrp.fstab
@@ -1,10 +1,21 @@
-/boot		   emmc 	/dev/block/platform/mtk-msdc.0/by-name/boot
-/system		   ext4 	/dev/block/platform/mtk-msdc.0/by-name/system
-/data		   ext4 	/dev/block/platform/mtk-msdc.0/by-name/userdata
-/cache		   ext4 	/dev/block/platform/mtk-msdc.0/by-name/cache
-/recovery	   ext4 	/dev/block/platform/mtk-msdc.0/by-name/recovery		flags=display="Recovery";backup=1
-/oem		   ext4 	/dev/block/platform/mtk-msdc.0/by-name/oem		flags=display="OEM";backup=1
-/logo		   ext4 	/dev/block/platform/mtk-msdc.0/by-name/logo		flags=display="LOGO";backup=1
-/frp		   ext4 	/dev/block/platform/mtk-msdc.0/by-name/frp		flags=display="FRP Counter";wipeingui
-/nvram		   ext4 	/dev/block/platform/mtk-msdc.0/by-name/nvram		flags=display="IMEI";backup=1
-/external_sd	   vfat 	/dev/block/mmcblk1p1                               /dev/block/mmcblk1   flags=display="External SDCard";storage;wipeingui;removable
+/boot           emmc     /dev/block/platform/mtk-msdc.0/by-name/boot
+/recovery       emmc     /dev/block/platform/mtk-msdc.0/by-name/recovery          flags=display="Recovery";backup=1
+/system         ext4     /dev/block/platform/mtk-msdc.0/by-name/system
+/data           ext4     /dev/block/platform/mtk-msdc.0/by-name/userdata
+/cache          ext4     /dev/block/platform/mtk-msdc.0/by-name/cache
+/external_sd    vfat     /dev/block/mmcblk1p1      /dev/block/mmcblk1             flags=display="External SDCard";storage;wipeingui;removable
+/usb_otg        vfat     /dev/block/sda1           /dev/block/sda                 flags=display="USB OTG";storage;wipeingui;removable
+/proinfo        emmc     /dev/block/platform/mtk-msdc.0/by-name/proinfo           flags=display="Pro-Info";backup=1
+/nvram          emmc     /dev/block/platform/mtk-msdc.0/by-name/nvram             flags=display="NV-RAM";backup=1
+/protect_f      ext4     /dev/block/platform/mtk-msdc.0/by-name/protect1          flags=display="Protect-F";backup=1
+/protect_s      ext4     /dev/block/platform/mtk-msdc.0/by-name/protect2          flags=display="Protect-S";backup=1
+/seccfg         emmc     /dev/block/platform/mtk-msdc.0/by-name/seccfg            flags=display="Seccfg";backup=1
+/bootloader     emmc     /dev/block/platform/mtk-msdc.0/by-name/bootloader        flags=display="Boot-Loader";backup=1
+/secro          emmc     /dev/block/platform/mtk-msdc.0/by-name/secro             flags=display="Secro";backup=1
+/para           emmc     /dev/block/platform/mtk-msdc.0/by-name/para              flags=display="Para";backup=1
+/logo           emmc     /dev/block/platform/mtk-msdc.0/by-name/logo              flags=display="Logo";backup=1
+/expdb          emmc     /dev/block/platform/mtk-msdc.0/by-name/expdb             flags=display="Expdb";backup=1
+/oem            ext4     /dev/block/platform/mtk-msdc.0/by-name/oem               flags=display="OEM";backup=1
+/metadata       emmc     /dev/block/platform/mtk-msdc.0/by-name/metadata          flags=display="MetaData";backup=1
+/persistent     emmc     /dev/block/platform/mtk-msdc.0/by-name/frp               flags=display="Persistent [FRP]";backup=1;wipeingui
+/gen            emmc     /dev/block/platform/mtk-msdc.0/by-name/gen               flags=display="GEN";backup=1

--- a/rootdir/root/fstab.sprout
+++ b/rootdir/root/fstab.sprout
@@ -13,3 +13,4 @@
 /dev/block/platform/mtk-msdc.0/by-name/oem       /oem        ext4       ro,context=u:object_r:oemfs:s0,nosuid,nodev                 wait
 /devices/platform/mtk-msdc.1/mmc_host*           auto        auto       defaults                                                    voldmanaged=sdcard0:auto,encryptable=userdata,noemulatedsd
 /dev/block/platform/mtk-msdc.0/by-name/frp       /persistent emmc       defaults                                                    defaults
+/devices/platform/mt_usb*                        auto        vfat       defaults                                                    voldmanaged=usbotg:auto,encryptable=userdata

--- a/seedmtk.mk
+++ b/seedmtk.mk
@@ -24,4 +24,4 @@ PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/rootdir/root/init.sprout.rc:root/init.sprout.rc \
     $(LOCAL_PATH)/rootdir/root/fstab.sprout:root/fstab.sprout \
     $(LOCAL_PATH)/rootdir/root/kernel:kernel \
-    $(LOCAL_PATH)/rootdir/recovery/twrp.fstab:root/etc/twrp.fstab
+    $(LOCAL_PATH)/rootdir/recovery/twrp.fstab:recovery/root/etc/twrp.fstab

--- a/seedmtk.mk
+++ b/seedmtk.mk
@@ -22,5 +22,6 @@ $(call inherit-product-if-exists, device/mediatek/sprout-common/sprout.mk)
 
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/rootdir/root/init.sprout.rc:root/init.sprout.rc \
-    $(LOCAL_PATH)/rootdir/root/fstab.sprout:root/fstab.sprout	\
-    $(LOCAL_PATH)/rootdir/root/kernel:kernel
+    $(LOCAL_PATH)/rootdir/root/fstab.sprout:root/fstab.sprout \
+    $(LOCAL_PATH)/rootdir/root/kernel:kernel \
+    $(LOCAL_PATH)/rootdir/recovery/twrp.fstab:root/etc/twrp.fstab


### PR DESCRIPTION
Kindly Try with this changes , to fix `Pixel V1` Partition Detection.   

1. Added all partition in `twrp.fstab` located at `rootdir/recovery/twrp.fstab`.   
2. Added USB-OTG detection in `fstab.sprout` at `rootdir/root/fstab.sprout`.   
3. Added this line `$(LOCAL_PATH)/rootdir/recovery/twrp.fstab:root/etc/twrp.fstab` for `PRODUCT_COPY_FILES` in `seedmtk.mk`  by referring on XDA here : [[DEV]How to compile TWRP touch recovery](https://forum.xda-developers.com/showthread.php?t=1943625).   

If anyone can build it , then I can test it on my device.
(Just do not know how to build from Source on Windows)
@Dees-Troy , @bigbiff  & of-course @MSF-Jarvis Kindly take a note.

I have tested by Un-Packing the `.img` file and then Re-Pack it and flash.
Works Flawlessly , Including `USB OTG`. 😄 .

Best Regards.
